### PR TITLE
Fix check-in calendar for non-UTC timezones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+.DS_Store
+node_modules/
+/dist/
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw*

--- a/src/components/modal/signInModal.vue
+++ b/src/components/modal/signInModal.vue
@@ -136,7 +136,7 @@ const tableHead = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const tableBody = reactive([]);
 const contractList = ref([]);
 const historyList = ref([]);
-const date = ref(moment(new Date()).format("MMM YYYY"));
+const date = ref(moment(new Date()).utc().format("MMM YYYY"));
 
 const showArrowRight = ref(true);
 const showArrowLeft = computed(() => {
@@ -336,9 +336,9 @@ const mapInit = () => {
       tableBody[index] = {
         ...tableBody[index],
         click:
-          value == moment(new Date()).format("D") &&
-          dateIos.month() === moment(new Date()).month() &&
-          dateIos.year() === moment(new Date()).year(),
+          value == moment(new Date()).utc().format("D") &&
+          dateIos.month() === moment(new Date()).utc().month() &&
+          dateIos.year() === moment(new Date()).utc().year(),
       };
     } else {
       tableBody[index] = {


### PR DESCRIPTION
## Description

Calendar shows correct check-in dates for previous days, but fails to make the check-in button clickable for current (UTC) day. This PR fixes that by showing current UTC day as the one that can be interacted with.

## Example
While using UTC-3, try to check-in between 21:00-23:59 (00:00-02:59 UTC). Check-in will show current UTC-3 day, while after confirming the transaction, the next day will be the one marked.

Also, check-in can't be completed for current UTC day for that period if previous day was already marked as completed.

I have also added a `.gitignore` file.