### PR TITLE
fixing width issues on firefox. The icon was not seen.

### DIFF
--- a/src/assets/css/mixin.scss
+++ b/src/assets/css/mixin.scss
@@ -84,7 +84,7 @@
 }
 
 @mixin img_size($w:20px, $h:20px) {
-  max-width: $w;
+  width: $w;
   max-height: $h;
   line-height: $h;
 


### PR DESCRIPTION
On firefox the icon for change the theme was missing. I fixed that by setting the width instead of max-width.

<img width="411" alt="grafik" src="https://github.com/owlto-finance/owlto-frontend/assets/14287880/0c73235d-b3a8-43c3-9887-f31e1bb3ef43">

